### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/matthope/78ffe4c7-140c-4b90-8617-0f04c6245952/b4ecc454-98d2-4b48-be25-c3fb48a96992/_apis/work/boardbadge/e6ea94c9-c81e-4cb4-b7bf-acb2c852692c)](https://dev.azure.com/matthope/78ffe4c7-140c-4b90-8617-0f04c6245952/_boards/board/t/b4ecc454-98d2-4b48-be25-c3fb48a96992/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.